### PR TITLE
Changed 'mendor' to 'mentor'

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 
         <p>The hackathon organizer must make sure that everyone has something to do. One way to do this is to have a list of project leaders ahead of time: people you know are coming with particular projects that you can guide other participants to. And you can work to make sure your hacking projects are ready to accept newcomers. You can also hold non-project activities &mdash; workshops, described below &mdash; which are easier for newcomers to join.</p>
 
-        <p>You could also consider pairing newcomers with mendors or holding a pre-event session just for newcomers, as <a href="https://blog.wikimedia.org/2017/05/31/vienna-hackathon-learnings/">Wikimedia recently did</a>.</p>
+        <p>You could also consider pairing newcomers with mentors or holding a pre-event session just for newcomers, as <a href="https://blog.wikimedia.org/2017/05/31/vienna-hackathon-learnings/">Wikimedia recently did</a>.</p>
 
 
         <h2 id="hacking">Hacking</h2>


### PR DESCRIPTION
I don't think 'mendors' is a word. I'm assuming this is a typo of the word 'mentors'.