### PR TITLE
Add "See also" section with link to https://hackathons.hackclub.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,6 +493,10 @@
           <li>Blog about the event</li>
         </ul>
 
+        <h2 id="see-also">See also</h2>
+
+        <p>If you're a high school student, you may want to check out <a href="https://hackathons.hackclub.com">https://hackathons.hackclub.com</a> to find events to attend or to list your event to get exposure.</p>
+
       </div>
 
       <hr>


### PR DESCRIPTION
Hey, I hate to be "that guy" with this PR, but I think what we're building is important and I think many of the visitors to your site are students & would benefit from it.

I run [Hack Club](https://hackclub.com), which is a 501(c)(3) non-profit dedicated to fostering the hacker culture in high schools. We recently launched https://hackathons.hackclub.com in [this tweet](https://twitter.com/zachlatta/status/1006318924902719488) because, until now, there has been no centralized resource with all of the high school events. Potential attendees have been left in the dark and organizers have struggled to get attendance.

[![image](https://user-images.githubusercontent.com/992248/41379796-d986f3d6-6f17-11e8-8c84-5bd181530892.png)](https://hackathons.hackclub.com)

I've been reaching out to the creators of the most prominent hackathon resources asking for their help in spreading the word. Here's what the site looks like before this PR:

![2018-06-13-143034_910x468_scrot](https://user-images.githubusercontent.com/992248/41379566-2ab52116-6f17-11e8-83e6-0c853e1f9110.png)

 And after:

![2018-06-13-143021_986x602_scrot](https://user-images.githubusercontent.com/992248/41379571-2f3bd158-6f17-11e8-90d8-61bc5bef831e.png)

Let me know what you think about merging this. Would truly appreciate if you helped us out here.