### PR TITLE
Update URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <div class="container">
       <div id="body-content">
 
-        <p>These notes come from five successful years of <a href="http://dc.opendataday.org">Open Data Day DC</a> and other civic hackathons that I&rsquo;ve run, sponsored, or participated in.</p>
+        <p>These notes come from five successful years of <a href="http://opendataday.org/">Open Data Day DC</a> and other civic hackathons that I&rsquo;ve run, sponsored, or participated in.</p>
 
         <p>The ideas have been inspired by many individuals, especially including my Open Data Day DC co-organizers Eric Mill, Sam Lee, Katherine Townsend, and Julia Bezgacheva, as well as Justin Grimes, Matt Bailey, Leah Bannon, Laurenellen McCann, and Greg Bloom.</p>
 


### PR DESCRIPTION
dc.opendataday.org doesn't exist - updated it to the main site.